### PR TITLE
Update to fully support the DefaultRoute identifier

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -204,6 +204,7 @@ func validateAgentIdentifiers(agentIdentifiers string) error {
 		case agent.IPv6:
 		case agent.CIDR:
 		case agent.Host:
+		case agent.DefaultRoute:
 		default:
 			return fmt.Errorf("unknown address type: %s", idType)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -315,6 +315,8 @@ func NewProxyServer(serverID string, proxyStrategies []ProxyStrategy, serverCoun
 			bms = append(bms, NewDestHostBackendManager())
 		case ProxyStrategyDefault:
 			bms = append(bms, NewDefaultBackendManager())
+		case ProxyStrategyDefaultRoute:
+			bms = append(bms, NewDefaultRouteBackendManager())
 		default:
 			klog.V(4).InfoS("Unknonw proxy strategy", "strategy", ps)
 		}


### PR DESCRIPTION
Fixes:
```
I0603 12:00:18.681818       1 server.go:319] "Unknonw proxy strategy" strategy=defaultRoute
```
and
```
Error: failed to validate agent options with agent address is invalid: unknown address type: default-route
Usage:
  agent [flags]

Flags:...
```